### PR TITLE
implement that uploaded pics can be seen in the show page and centered picture inpu

### DIFF
--- a/app/assets/stylesheets/components/_art_piece_card.scss
+++ b/app/assets/stylesheets/components/_art_piece_card.scss
@@ -39,3 +39,10 @@
 	width: 100%;
 	object-fit: cover;
 }
+
+.img-show {
+  height: 800px;
+  width: 100%;
+  object-fit: cover;
+
+}

--- a/app/views/art_pieces/new.html.erb
+++ b/app/views/art_pieces/new.html.erb
@@ -15,7 +15,9 @@
           <%= f.input :artist, placeholder: 'Picasso' %>
           <%= f.input :description, placeholder: 'please take a moment to describe your art piece in a few sentences' %>
           <%= f.input :price, placeholder: 'price per month' %>
-          <%= f.input :photos, as: :file, input_html: { multiple: true }, class: "center-field" %>
+          <div class="container d-flex justify-content-center">
+            <%= f.input :photos, as: :file, input_html: { multiple: true }, hint: 'please upload high-resolution pictures' %>
+          </div>
           <%= f.submit class: "btn btn-flat-create mt-3" %>
         <% end %>
       </div>

--- a/app/views/art_pieces/show.html.erb
+++ b/app/views/art_pieces/show.html.erb
@@ -7,15 +7,11 @@
       <div class="col-12 col-centered">
         <div id="carouselExampleControls" class="carousel slide" data-ride="carousel">
           <div class="carousel-inner">
-            <div class="carousel-item">
-              <img src="https://picsum.photos/800/350" class="d-block w-100 mt-4 rounded" alt="...">
-            </div>
-            <div class="carousel-item active">
-              <img src="https://picsum.photos/800/350" class="d-block w-100 mt-4 rounded" alt="...">
-            </div>
-            <div class="carousel-item">
-              <img src="https://picsum.photos/800/350" class="d-block w-100 mt-4 rounded" alt="...">
-            </div>
+            <% @art_piece.photos.each_with_index do |photo, i| %>
+              <div class="carousel-item <%= "active" if i.zero? %>">
+                <%= cl_image_tag photo.key, crop: :fill, class:"img-show" %>
+              </div>
+            <% end %>
           </div>
           <a class="carousel-control-prev" href="#carouselExampleControls" role="button" data-slide="prev">
             <span class="carousel-control-prev-icon" aria-hidden="true"></span>


### PR DESCRIPTION
- user can now see their uploaded pictures in the carousel in the show page, the carousel is not hardcoded so it will show as many pics as the user uploads 
- I centered the picture upload button (it doesn't look centered but it is centered) and I added a hint that user should only upload high resolution pics --> pics form Google will be pixelated and thus will not work --> we have to think how we seed then for tomorrow because we should use real pics and not some from google 